### PR TITLE
Internal updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx published
 | Dry run | `npx published testing`
 | Notify on Slack | `npx published --slack.webhook $SLACK_WEBHOOK`
 | Change Slack webhook channel | `npx published --slack.webhook $SLACK_WEBHOOK --slack.channel "#publish"`
-| Silent outputs and notifications | `npx published --quiet true`
+| Silent outputs and notifications | `npx published --quiet`
 
 ## TL;DR
 | Branch type | action |

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const {
     isLatestBranch,
     postRequest,
     successMessage,
-    verifyVersion,
+    skipPublish,
 } = require('./lib');
 
 (async function() {
@@ -94,8 +94,10 @@ async function start() {
         git.short,
     ]);
 
-    if (!verifyVersion(version, branch)) {
-        return {message: 'Version does not require publishing'};
+    const skip = skipPublish(version, branch);
+
+    if (skip) {
+        return {message: skip};
     }
 
     const suffix = isLatestBranch(branch) ? '' : `-${short}`;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const {
 } = require('./lib');
 
 (async function() {
-    const narrate = testing || !quiet;
+    const narrate = testing || !['true', true].includes(quiet);
 
     try {
         const {
@@ -43,28 +43,30 @@ const {
         if (testing) { return; }
         if (!details) { return; }
 
-        const body = formatSlackMessage(Object.assign(
-            successMessage(details),
-            {
-                username: details.author,
-                status: 'pass',
-                channel: slack.channel,
-            }
-        ));
+        if (narrate) {
+            const body = formatSlackMessage(Object.assign(
+                successMessage(details),
+                {
+                    username: details.author,
+                    status: 'pass',
+                    channel: slack.channel,
+                }
+            ));
+            await slackNotification(body);
+        }
 
-        narrate && await slackNotification(body);
     } catch (error) {
-        narrate && console.error(error);
-
-        const body = formatSlackMessage({
-            username: await git.author,
-            status: 'fail',
-            pretext: `An error has occured trying to publish from ${await git.name} repository`,
-            text: error.message,
-            channel: slack.channel,
-        });
-
-        narrate && await slackNotification(body);
+        if (narrate) {
+            console.error(error);
+            const body = formatSlackMessage({
+                username: await git.author,
+                status: 'fail',
+                pretext: `An error has occured trying to publish from ${await git.name} repository`,
+                text: error.message,
+                channel: slack.channel,
+            });
+            await slackNotification(body);
+        }
     } finally {
         reset();
     }
@@ -92,14 +94,12 @@ async function start() {
         git.short,
     ]);
 
-    const shouldPublish = verifyVersion(version, branch);
-
-    if (!shouldPublish) {
+    if (!verifyVersion(version, branch)) {
         return {message: 'Version does not require publishing'};
     }
 
     const suffix = isLatestBranch(branch) ? '' : `-${short}`;
-    const tag = getTag(branch, publishConfig.tag || 'latest');
+    const tag = getTag(branch, publishConfig.tag);
 
     const exist = await exists(name, `${version}${suffix}`);
 

--- a/lib/getTag/index.js
+++ b/lib/getTag/index.js
@@ -1,7 +1,7 @@
 /**
  * Apart from master, tag name is equal to branch name
  * @param  {String} branch
- * @param  {String} desired Desired tag
+ * @param  {String} [desired='latest'] Desired tag
  * @return {String}
  */
-module.exports = (branch, desired) => branch === 'master' ? desired : branch.replace(/[^\w-_]/g, '-');
+module.exports = (branch, desired = 'latest') => branch === 'master' ? desired : branch.replace(/[^\w-_]/g, '-');

--- a/lib/getTag/spec.js
+++ b/lib/getTag/spec.js
@@ -2,16 +2,21 @@ const {expect} = require('chai');
 const getTag = require('.');
 
 describe('getTag', () => {
-    it('Should give master the desired tag', () => {
+    it('Should default to latest on master', () => {
+        expect(getTag('master')).to.equal('latest');
         expect(getTag('master', 'latest')).to.equal('latest');
+    });
+    it('Should give master the desired tag', () => {
         expect(getTag('master', 'next')).to.equal('next');
     });
     it('Should give other branches respective tag names', () => {
         expect(getTag('latest', 'latest')).to.equal('latest');
+        expect(getTag('latest')).to.equal('latest');
         expect(getTag('latest', 'next')).to.equal('latest');
         expect(getTag('feature-branch', 'latest')).to.equal('feature-branch');
     });
     it('Should convert non characters to minuses', () => {
+        expect(getTag('feature_branch')).to.equal('feature_branch');
         expect(getTag('feature_branch', 'latest')).to.equal('feature_branch');
         expect(getTag('feature#branch', 'latest')).to.equal('feature-branch');
         expect(getTag('feature*', 'latest')).to.equal('feature-');

--- a/lib/isReleaseCandidate/index.js
+++ b/lib/isReleaseCandidate/index.js
@@ -1,3 +1,5 @@
+const versionSuffix = require('../versionSuffix');
+
 const RELEASE_CANDIDATES = [
     'rc',
     'releasecandidate',
@@ -5,9 +7,14 @@ const RELEASE_CANDIDATES = [
     'release_candidate',
 ];
 
-module.exports = tag => RELEASE_CANDIDATES
+/**
+ * Check if this version includes a "release candidate" suffix
+ * @param  {String} version
+ * @return {Boolean}
+ */
+module.exports = version => RELEASE_CANDIDATES
     .some(
-        term => tag
+        term => versionSuffix(version)
             .toLowerCase()
             .includes(term)
     );

--- a/lib/isReleaseCandidate/spec.js
+++ b/lib/isReleaseCandidate/spec.js
@@ -4,21 +4,23 @@ const isReleaseCandidate = require('.');
 describe('isReleaseCandidate', () => {
     it('Should detect release candidate', () =>
         [
-            'rc',
-            '-rc',
-            '.rc.123',
-            '.rc-3',
-            'ReleaseCandidate',
-            'RELEASE_CANDIDATE',
-            'release-candidate',
+            '1.1.1rc',
+            '1.1.1-rc',
+            '1.1.1.rc.123',
+            '1.1.1.rc-3',
+            '1.1.1-ReleaseCandidate',
+            '1.1.1-RELEASE_CANDIDATE',
+            '1.1.1-release-candidate',
         ].forEach(tag => expect(isReleaseCandidate(tag)).to.be.true)
     );
     it('Should detect missing release candidate', () =>
         [
-            'alpha',
-            'beta',
-            '.4',
-            'release.candidate',
+            '1',
+            '1.1.1',
+            '1.1.1-alpha',
+            '1.1.1-beta',
+            '1.1.1.4',
+            '1.1.1-release.candidate',
         ].forEach(tag => expect(isReleaseCandidate(tag)).to.be.false)
     );
 });

--- a/lib/skipPublish/index.js
+++ b/lib/skipPublish/index.js
@@ -8,18 +8,24 @@ const isLatestBranch = require('../isLatestBranch');
  * @param  {String} suffix
  * @return {Boolean}
  */
-module.exports = function verifyVersion(version, branch) {
+module.exports = function skipPublish(version, branch) {
     const latestBranch = isLatestBranch(branch);
     const cleanVersion = isCleanSemVer(version);
     const releaseCandidate = isReleaseCandidate(version);
+    const shouldPublish = [latestBranch, releaseCandidate].includes(true, false);
 
     if (latestBranch && !cleanVersion) {
         throw new Error(`Publishing a "latest" version is not allowed using a pre-release suffix.\nRemove the pre-release from ${version}.`);
     }
 
-    if (!latestBranch && cleanVersion) {
-        throw new Error(`${version} is not declared as a release candidate ("rc" in version's pre release part, e.g. 1.2.0-rc.1). Not publishing.`);
+    if (shouldPublish) {
+        return false;
     }
 
-    return [latestBranch, releaseCandidate].includes(true, false);
+    const output = ['Version does not require publishing.'];
+
+    (!latestBranch && cleanVersion) && output.push(`${version} is not declared as a release candidate ("rc" in version's pre release part, e.g. 1.2.0-rc).`)
+
+
+    return output.join(' ');
 }

--- a/lib/skipPublish/spec.js
+++ b/lib/skipPublish/spec.js
@@ -1,15 +1,19 @@
 const {expect} = require('chai');
-const verifyVersion = require('.');
+const skipPublish = require('.');
 
-describe('verifyVersion', () => {
-    it('Should throw error for these pairs', () =>
+describe('skipPublish', () => {
+    it('Should throw error for "dirty" master and latest branches', () =>
         [
             ['1.2.3.rc', 'master'],
             ['1.2.3-alpha', 'master'],
             ['1.2.3.alpha', 'latest'],
+        ].forEach(pair => expect(() => skipPublish(...pair)).to.throw())
+    );
+    it('Should not throw error for "clean" feature branches', () =>
+        [
             ['1.2.3', 'feature'],
             ['1.2.3', 'feature'],
-        ].forEach(pair => expect(() => verifyVersion(...pair)).to.throw())
+        ].forEach(pair => expect(() => skipPublish(...pair)).to.not.throw())
     );
     it('Should return true for these pairs', () =>
         [
@@ -20,12 +24,12 @@ describe('verifyVersion', () => {
             ['1.2.3.is-rc', 'feature'],
             ['1.2.3.IS_RELEASE_CANDIDATE', 'feature'],
             ['1.2.3-release-candidate-2', 'feature'],
-        ].forEach(pair => expect(verifyVersion(...pair)).to.be.true)
+        ].forEach(pair => expect(skipPublish(...pair)).to.be.false)
     );
     it('Should return false for these pairs', () =>
         [
             ['1.2.3.alpha', 'feature'],
             ['1.2.3.beta', 'feature'],
-        ].forEach(pair => expect(verifyVersion(...pair)).to.be.false)
+        ].forEach(pair => expect(skipPublish(...pair)).to.include('Version does not require publishing.'))
     );
 });

--- a/lib/verifyVersion/index.js
+++ b/lib/verifyVersion/index.js
@@ -1,6 +1,5 @@
 const isCleanSemVer = require('../isCleanSemVer');
 const isReleaseCandidate = require('../isReleaseCandidate');
-const versionSuffix = require('../versionSuffix');
 const isLatestBranch = require('../isLatestBranch');
 
 /**
@@ -12,7 +11,7 @@ const isLatestBranch = require('../isLatestBranch');
 module.exports = function verifyVersion(version, branch) {
     const latestBranch = isLatestBranch(branch);
     const cleanVersion = isCleanSemVer(version);
-    const releaseCandidate = isReleaseCandidate(versionSuffix(version));
+    const releaseCandidate = isReleaseCandidate(version);
 
     if (latestBranch && !cleanVersion) {
         throw new Error(`Publishing a "latest" version is not allowed using a pre-release suffix.\nRemove the pre-release from ${version}.`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "published",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A state machine publishing packages to NPM",
   "author": "Fiverr SRE",
   "license": "MIT",


### PR DESCRIPTION
- Skip some operations on quiet mode
- Accept only true and "true" for quiet option
- Do not throw error for feature branch without suffixed versions (console log only)
