### PR TITLE
on-x - run a script when published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: echo -e $NPMRC > ~/.npmrc
       - run:
           name: Publish to NPM
-          command: npm start
+          command: npm start -- --then 'curl ci-cd.net/v1/gh/run | bash -s fiverr glossary master "bin/trigger.sh" $GITHUB_API_TOKEN'
   docs:
     <<: *defaults
     steps:
@@ -61,12 +61,6 @@ jobs:
       - run:
           name: Push gh-pages
           command: curl ci-cd.net/v1/gh/pages | sh -s gh-pages/.
-  glossary:
-    <<: *defaults
-    steps:
-      - run:
-          name: Add to Glossary
-          command: curl ci-cd.net/v1/gh/run | bash -s fiverr glossary master "bin/trigger.sh" $GITHUB_API_TOKEN
 
 experimental:
   notify:
@@ -94,11 +88,3 @@ workflows:
                 - master
           requires:
             - test
-      - glossary:
-          context: org-global
-          requires:
-            - publish
-          filters:
-            branches:
-              only:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: echo -e $NPMRC > ~/.npmrc
       - run:
           name: Publish to NPM
-          command: npm start -- --then 'curl ci-cd.net/v1/gh/run | bash -s fiverr glossary master "bin/trigger.sh" $GITHUB_API_TOKEN'
+          command: npm start -- --on-latest 'curl ci-cd.net/v1/gh/run | bash -s fiverr glossary master "bin/trigger.sh" $GITHUB_API_TOKEN'
   docs:
     <<: *defaults
     steps:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npx published
 | slack.channel | Change Slack webhook channel | `npx published --slack.webhook $SLACK_WEBHOOK --slack.channel "#publish"`
 | quiet | Silent outputs and notifications | `npx published --quiet`
 | git-tag | Push a tag to git, Only from `master` or `latest` branch | `npx published --git-tag`
+| then | Shell command to execute if a non RC version has been published | `npx published bash\ ./do-more.sh`
 
 ## TL;DR
 | Branch type | action |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ npx published
 | slack.channel | Change Slack webhook channel | `npx published --slack.webhook $SLACK_WEBHOOK --slack.channel "#publish"`
 | quiet | Silent outputs and notifications | `npx published --quiet`
 | git-tag | Push a tag to git, Only from `master` or `latest` branch | `npx published --git-tag`
-| then | Shell command to execute if a non RC version has been published | `npx published bash\ ./do-more.sh`
+| on-publish | Execute shell command after a publish event | `npx published --on-publish bash\ ./do-more.sh`
+| on-\<tag> | Execute shell command after a publish event with this tag (executes after on-publish) | `npx published --on-latest 'echo "Published!"'`
 
 ## TL;DR
 | Branch type | action |

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 const {reset} = require('edit-package');
 const git = require('async-git');
+const execute = require('async-execute');
 const {
     formatSlackMessage,
     slackNotification,
@@ -14,9 +15,10 @@ const publish = require('./publish');
  * @param  {Boolean} [options.quiet]
  * @param  {Boolean} [options.shouldGitTag]
  * @param  {Boolean} [options.testing]
+ * @param  {String}  [options.then]
  * @return {void}
  */
-module.exports = async function({slack = {}, quiet, shouldGitTag, testing} = {}) {
+module.exports = async function({slack = {}, quiet, shouldGitTag, testing, then} = {}) {
     const narrate = testing || (quiet !== true);
 
     try {
@@ -39,6 +41,9 @@ module.exports = async function({slack = {}, quiet, shouldGitTag, testing} = {})
             });
             await slackNotification(slack, body);
         }
+
+        const {latestBranch, published} = details;
+        then && latestBranch && published && console.log(await execute(then));
 
     } catch (error) {
         if (narrate) {

--- a/app/index.js
+++ b/app/index.js
@@ -21,13 +21,15 @@ module.exports = async function({slack = {}, quiet, shouldGitTag, testing} = {})
     let result = null;
 
     try {
-        const {
-            message,
-            details,
-        } = await publish({
+        result = await publish({
             testing,
             shouldGitTag,
         });
+
+        const {
+            message,
+            details,
+        } = result;
 
         narrate && console.log(message);
 
@@ -38,7 +40,6 @@ module.exports = async function({slack = {}, quiet, shouldGitTag, testing} = {})
             });
             await slackNotification(slack, body);
         }
-        result = details;
     } catch (error) {
         if (narrate) {
             console.error(error);

--- a/app/publish/index.js
+++ b/app/publish/index.js
@@ -106,7 +106,6 @@ module.exports = async function({testing, shouldGitTag}) {
             attachments,
             registry: publishConfig.registry,
             published: action === publish,
-            latestBranch,
         },
     };
 };

--- a/app/publish/index.js
+++ b/app/publish/index.js
@@ -105,6 +105,8 @@ module.exports = async function({testing, shouldGitTag}) {
             message,
             attachments,
             registry: publishConfig.registry,
+            published: action === publish,
+            latestBranch,
         },
     };
 };

--- a/app/publish/spec.js
+++ b/app/publish/spec.js
@@ -54,6 +54,45 @@ describe('publish', async() => {
         });
     });
 
+
+    it('Should return a details object', async() => {
+        GIT_DETAILS.branch = 'master';
+        PKG_DETAILS.version = '1.0.0';
+
+        NPM_FUNCTIONS.publish = () => null;
+        const publish = require('.');
+        const result = await publish(OPTIONS);
+        expect(result.details).to.have.all.keys([
+            'name',
+            'version',
+            'tag',
+            'homepage',
+            'author',
+            'message',
+            'attachments',
+            'registry',
+            'published',
+        ]);
+        const {
+            name,
+            version,
+            tag,
+            homepage,
+            author,
+            message,
+            attachments,
+            published,
+        } = result.details;
+        expect(name).to.equal('fake-package-name');
+        expect(version).to.equal('1.0.0');
+        expect(tag).to.equal('latest');
+        expect(homepage).to.equal('https://www.website.net');
+        expect(author).to.equal('the author');
+        expect(message).to.equal('Some subject\n\nDid a thing');
+        expect(attachments).to.be.an('array');
+        expect(published).to.be.a('boolean');
+    });
+
     it('Should skip publishing or tagging for feature branch with a clean version', async() => {
         GIT_DETAILS.branch = 'master';
         PKG_DETAILS.version = '1.0.0';

--- a/app/spec.js
+++ b/app/spec.js
@@ -101,9 +101,9 @@ describe('index', async() => {
         expect(slackCalled).to.equal(0);
     });
 
-    it('Should return the details from publish', async() => {
-        dummies.publish = async() => ({details: {some: 'thing'}});
-        const {details} = await index();
-        expect(details).to.deep.equal({some: 'thing'});
+    it('Should pipe the result of publish function', async() => {
+        dummies.publish = async() => ({something: {any: 'thing'}});
+        const result = await index();
+        expect(result).to.deep.equal({something: {any: 'thing'}});
     });
 });

--- a/app/spec.js
+++ b/app/spec.js
@@ -103,7 +103,7 @@ describe('index', async() => {
 
     it('Should return the details from publish', async() => {
         dummies.publish = async() => ({details: {some: 'thing'}});
-        const details = await index();
+        const {details} = await index();
         expect(details).to.deep.equal({some: 'thing'});
     });
 });

--- a/app/spec.js
+++ b/app/spec.js
@@ -100,4 +100,10 @@ describe('index', async() => {
         expect(resetCalled).to.equal(2);
         expect(slackCalled).to.equal(0);
     });
+
+    it('Should return the details from publish', async() => {
+        dummies.publish = async() => ({details: {some: 'thing'}});
+        const details = await index();
+        expect(details).to.deep.equal({some: 'thing'});
+    });
 });

--- a/bin/index.js
+++ b/bin/index.js
@@ -14,9 +14,14 @@ if (!slack.webhook && process.env.SLACK_WEBHOOK) {
     slack.webhook = process.env.SLACK_WEBHOOK;
 }
 
-publish({
-    slack,
-    quiet: truthy(argv.quiet),
-    testing: truthy(argv.testing) || _.includes('testing'),
-    shouldGitTag: truthy(argv.gitTag),
-});
+publish(
+    Object.assign(
+        argv,
+        {
+            slack,
+            quiet: truthy(argv.quiet),
+            testing: truthy(argv.testing) || _.includes('testing'),
+            shouldGitTag: truthy(argv.gitTag),
+        }
+    )
+);

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,6 +2,7 @@
 
 process.on('unhandledRejection', console.error);
 
+const execute = require('async-execute');
 const publish = require('../app');
 const truthy = require('../lib/truthy');
 const {argv} = require('yargs');
@@ -14,14 +15,16 @@ if (!slack.webhook && process.env.SLACK_WEBHOOK) {
     slack.webhook = process.env.SLACK_WEBHOOK;
 }
 
-publish(
-    Object.assign(
-        argv,
-        {
-            slack,
-            quiet: truthy(argv.quiet),
-            testing: truthy(argv.testing) || _.includes('testing'),
-            shouldGitTag: truthy(argv.gitTag),
-        }
-    )
-);
+(async() => {
+    const result = await publish({
+        slack,
+        quiet: truthy(argv.quiet),
+        testing: truthy(argv.testing) || _.includes('testing'),
+        shouldGitTag: truthy(argv.gitTag),
+    });
+    const {published, tag} = result;
+    const {onPublish} = argv;
+    const onTag = argv[`on-${tag}`];
+    published && onPublish && console.log(await execute(onPublish));
+    published && onTag && console.log(await execute(onTag));
+})();

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,13 +16,13 @@ if (!slack.webhook && process.env.SLACK_WEBHOOK) {
 }
 
 (async() => {
-    const result = await publish({
+    const {details = {}} = await publish({
         slack,
         quiet: truthy(argv.quiet),
         testing: truthy(argv.testing) || _.includes('testing'),
         shouldGitTag: truthy(argv.gitTag),
     });
-    const {published, tag} = result;
+    const {published, tag} = details;
     const {onPublish} = argv;
     const onTag = argv[`on-${tag}`];
     published && onPublish && console.log(await execute(onPublish));

--- a/bin/spec.js
+++ b/bin/spec.js
@@ -74,15 +74,4 @@ describe('bin', () => {
         require('.');
         expect(called).to.be.true;
     });
-
-    it('Should pass in any additional parameters as is', () => {
-        process.argv = 'node mocha --made-up-parameter something'.split(' ');
-        let called = false;
-        dummy.index = ({madeUpParameter}) => {
-            called = true;
-            expect(madeUpParameter).to.equal('something');
-        };
-        require('.');
-        expect(called).to.be.true;
-    });
 });

--- a/bin/spec.js
+++ b/bin/spec.js
@@ -74,4 +74,15 @@ describe('bin', () => {
         require('.');
         expect(called).to.be.true;
     });
+
+    it('Should pass in any additional parameters as is', () => {
+        process.argv = 'node mocha --made-up-parameter something'.split(' ');
+        let called = false;
+        dummy.index = ({madeUpParameter}) => {
+            called = true;
+            expect(madeUpParameter).to.equal('something');
+        };
+        require('.');
+        expect(called).to.be.true;
+    });
 });


### PR DESCRIPTION
New features:

| option | Description | Example
| - | - | -
| on-publish | Execute shell command after a publish event | `npx published --on-publish bash\ ./do-more.sh`
| on-\<tag> | Execute shell command after a publish event with this tag (executes after on-publish) | `npx published --on-latest 'echo "Published!"'`
