### PR TITLE
Add `--no-sha` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npx published
 | on-&lt;tag&gt; | Execute shell command after a publish event with this tag (executes after on-publish) | `npx published --on-latest 'echo "Published!"'`
 | latest-branch | Branch that is considered latest (default is 'master') | `npx published --latest-branch stable`
 | tag-name | Tag name to be used regardless of config. If performed from a branch other than `master`, needs to be used in conjunction with `latest-branch` option | `npx published --tag-name next --latest-branch next`
+| no-sha | Disables the commit's SHA suffix for RC versions | `npx published --no-sha`
 
 ## TL;DR
 | Branch type | action |
@@ -43,7 +44,7 @@ echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 #### Feature branch
 
 - Publish only versions with a pre-release section containing `rc` string
-- Branch versions get a suffix that matches the commit ID, so you can re install the same tag and get updates
+- Unless the `--no-sha` flag was passed, branch versions get a suffix that matches the commit ID, so you can re install the same tag and get updates
 - Tags are named after the branch name
 
 #### "master" branch
@@ -58,15 +59,17 @@ echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
 ### Examples
 
-| branch | version | publish | tag
-| - | - | - | -
-| `my_feature_branch`, `next` | `1.3.0` | nothing | N/A
-| `my_feature_branch`, `next` | `1.3.1-alpha` | nothing | N/A
-| `my_feature_branch`, `next` | `1.3.1-rc` | `1.3.1-rc-c447f6a` | `my_feature_branch`, `next`
-| `my_feature_branch`, `next` | `1.3.1-rc.1` | `1.3.1-rc.1-c447f6a` | `my_feature_branch`, `next`
-| `master`, `latest` | `1.3.0` | `1.3.0` | `latest`
-| `master`, `latest` | `1.3.0-beta` | Throws Error | N/A
-| `master`, `latest` | `1.3.0-rc` | Throws Error | N/A
+| branch | version | publish | tag | w/o sha
+| - | - | - | - | -
+| `my_feature_branch`, `next` | `1.3.0` | nothing | N/A | -
+| `my_feature_branch`, `next` | `1.3.1-alpha` | nothing | N/A | -
+| `my_feature_branch`, `next` | `1.3.1-rc` | `1.3.1-rc` | `my_feature_branch`, `next` | ✓
+| `my_feature_branch`, `next` | `1.3.1-rc.1` | `1.3.1-rc.1` | `my_feature_branch`, `next` | ✓
+| `my_feature_branch`, `next` | `1.3.1-rc` | `1.3.1-rc-c447f6a` | `my_feature_branch`, `next` | ✕
+| `my_feature_branch`, `next` | `1.3.1-rc.1` | `1.3.1-rc.1-c447f6a` | `my_feature_branch`, `next` | ✕
+| `master`, `latest` | `1.3.0` | `1.3.0` | `latest` | -
+| `master`, `latest` | `1.3.0-beta` | Throws Error | N/A | -
+| `master`, `latest` | `1.3.0-rc` | Throws Error | N/A | -
 
 > \* using `latest-branch` option will switch its behaviour with master
 

--- a/app/index.js
+++ b/app/index.js
@@ -14,11 +14,12 @@ const publish = require('./publish');
  * @param  {Boolean} [options.quiet]
  * @param  {Boolean} [options.shouldGitTag]
  * @param  {Boolean} [options.testing]
- * @param  {{String} [options.latestBranch]
+ * @param  {String}  [options.latestBranch]
  * @param  {String}  [options.tagName]
+ * @param  {Boolean} [options.noSha]
  * @return {void}
  */
-module.exports = async function({ slack = {}, quiet, shouldGitTag, testing, latestBranch, tagName } = {}) {
+module.exports = async function({ slack = {}, quiet, shouldGitTag, testing, latestBranch, tagName, noSha } = {}) {
     const narrate = testing || (quiet !== true);
     let result = null;
 
@@ -27,7 +28,8 @@ module.exports = async function({ slack = {}, quiet, shouldGitTag, testing, late
             testing,
             shouldGitTag,
             latestBranch,
-            tagName
+            tagName,
+            noSha
         });
 
         const {

--- a/app/publish/index.js
+++ b/app/publish/index.js
@@ -22,11 +22,12 @@ const {
  * Publish the package according to your opinion
  * @param  {Boolean} [options.testing]
  * @param  {Boolean} [options.shouldGitTag]
- * @param  {String} [options.latestBranch]
- * @param  {String} [options.tagName]
- * @return {Object} details of the publishing event
+ * @param  {String}  [options.latestBranch]
+ * @param  {String}  [options.tagName]
+ * @param  {Boolean} [options.noSha]
+ * @return {Object}  details of the publishing event
  */
-module.exports = async function({ testing, shouldGitTag, latestBranch, tagName }) {
+module.exports = async function({ testing, shouldGitTag, latestBranch, tagName, noSha }) {
     testing && console.log('Testing only, will not publish');
 
     const [
@@ -61,7 +62,7 @@ module.exports = async function({ testing, shouldGitTag, latestBranch, tagName }
         return { message: skip };
     }
 
-    const suffix = onLatestBranch ? '' : `-${short}`;
+    const suffix = onLatestBranch || noSha ? '' : `-${short}`;
     const fullVersion = `${version}${suffix}`;
     const tag = tagName || getTag(branch, publishConfig.tag, onLatestBranch);
     const exist = await exists(name, fullVersion);

--- a/app/publish/spec.js
+++ b/app/publish/spec.js
@@ -55,7 +55,6 @@ describe('publish', async() => {
         });
     });
 
-
     it('Should return a details object', async() => {
         GIT_DETAILS.branch = 'master';
         PKG_DETAILS.version = '1.0.0';
@@ -194,5 +193,29 @@ describe('publish', async() => {
             expect(error.message.toLowerCase()).to.contain('not allowed');
         }
         expect(threw).to.be.true;
+    });
+
+    describe('Version suffix', () => {
+        it('Should suffix the version\'s name if not in master branch', async() => {
+            GIT_DETAILS.branch = 'not-master';
+            PKG_DETAILS.version = '1.0.0-rc';
+            NPM_FUNCTIONS.publish = () => null;
+
+            const publish = require('.');
+            const { details: { version } } = await publish(OPTIONS);
+
+            expect(version).to.match(new RegExp(`${PKG_DETAILS.version}-.*`));
+        });
+
+        it('Should not suffix the version\'s name if not in master branch and `--no-sha` was passed', async() => {
+            GIT_DETAILS.branch = 'not-master';
+            PKG_DETAILS.version = '1.0.0-rc';
+            NPM_FUNCTIONS.publish = () => null;
+
+            const publish = require('.');
+            const { details: { version } } = await publish({ ...OPTIONS, noSha: true });
+
+            expect(version).to.eql(PKG_DETAILS.version);
+        });
     });
 });

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,7 +26,8 @@ if (!slack.webhook && process.env.SLACK_WEBHOOK) {
         testing: truthy(argv.testing) || _.includes('testing'),
         shouldGitTag: truthy(argv.gitTag),
         latestBranch: argv.latestBranch,
-        tagName: argv.tagName
+        tagName: argv.tagName,
+        noSha: truthy(argv.noSha)
     });
     const { published, tag } = details;
     const { onPublish } = argv;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "published",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "📦 Opinionated NPM publish program",
   "keywords": [
     "npm",


### PR DESCRIPTION
Add support for the `--no-sha` flag, enabling RC versions to be released without a SHA suffix to the version name.