### PR TITLE
[TMP] Allow beta versions publish flow

### DIFF
--- a/lib/skipPublish/index.js
+++ b/lib/skipPublish/index.js
@@ -9,10 +9,11 @@ const isReleaseCandidate = require('../isReleaseCandidate');
  */
 module.exports = function skipPublish(version, latestBranch) {
     const cleanVersion = isCleanSemVer(version);
+    const isBetaVersion = version.includes('beta');
     const releaseCandidate = isReleaseCandidate(version);
     const shouldPublish = [latestBranch, releaseCandidate].includes(true, false);
 
-    if (latestBranch && !cleanVersion) {
+    if (latestBranch && !cleanVersion && !isBetaVersion) {
         throw new Error(`Publishing a "latest" version is not allowed using a pre-release suffix.\nRemove the pre-release from ${version}.`);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "published",
-  "version": "1.8.4",
+  "version": "1.8.5-rc",
   "description": "📦 Opinionated NPM publish program",
   "keywords": [
     "npm",


### PR DESCRIPTION
Just to allow `Perseus 3` framework to be published under `npm i @fiverr-private/perseus@beta`