### PR TITLE
Add support for --prefix-git-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm exec published --yes
 | slack.channel | Change Slack webhook channel | `npm exec published --yes -- --slack.webhook $SLACK_WEBHOOK --slack.channel "#publish"`
 | quiet | Silent outputs and notifications | `npm exec published --yes -- --quiet`
 | git-tag | Push a tag to git, Only from `master`(latest-branch) or `latest` branch | `npm exec published --yes -- --git-tag`
+| prefix-git-tag | Choose a prefix that will be prepend to git tag. Only from `master`(latest-branch) or `latest` branch | `npm exec published --yes -- --git-tag --prefix-git-tag=my-prefix@`
 | on-publish | Execute shell command after a publish event | `npm exec published --yes -- --on-publish bash\ ./do-more.sh`
 | on-&lt;tag&gt; | Execute shell command after a publish event with this tag (executes after on-publish) | `npm exec published --yes -- --on-latest 'echo "Published!"'`
 | latest-branch | Branch that is considered latest (default is 'master') | `npm exec published --yes -- --latest-branch stable`

--- a/app/index.js
+++ b/app/index.js
@@ -13,13 +13,14 @@ const publish = require('./publish');
  * @param  {String}  [options.slack.channel]
  * @param  {Boolean} [options.quiet]
  * @param  {Boolean} [options.shouldGitTag]
+ * @param  {String}  [options.prefixGitTag]
  * @param  {Boolean} [options.testing]
  * @param  {String}  [options.latestBranch]
  * @param  {String}  [options.tagName]
  * @param  {Boolean} [options.noSha]
  * @return {void}
  */
-module.exports = async function({ slack = {}, quiet, shouldGitTag, testing, latestBranch, tagName, noSha } = {}) {
+module.exports = async function({ slack = {}, quiet, shouldGitTag, prefixGitTag, testing, latestBranch, tagName, noSha } = {}) {
     const narrate = testing || (quiet !== true);
     let result = null;
 
@@ -27,6 +28,7 @@ module.exports = async function({ slack = {}, quiet, shouldGitTag, testing, late
         result = await publish({
             testing,
             shouldGitTag,
+            prefixGitTag,
             latestBranch,
             tagName,
             noSha

--- a/app/publish/index.js
+++ b/app/publish/index.js
@@ -22,12 +22,13 @@ const {
  * Publish the package according to your opinion
  * @param  {Boolean} [options.testing]
  * @param  {Boolean} [options.shouldGitTag]
+ * @param  {String}  [options.prefixGitTag]
  * @param  {String}  [options.latestBranch]
  * @param  {String}  [options.tagName]
  * @param  {Boolean} [options.noSha]
  * @return {Object}  details of the publishing event
  */
-module.exports = async function({ testing, shouldGitTag, latestBranch, tagName, noSha }) {
+module.exports = async function({ testing, shouldGitTag, prefixGitTag, latestBranch, tagName, noSha }) {
     testing && console.log('Testing only, will not publish');
 
     const [
@@ -90,10 +91,11 @@ module.exports = async function({ testing, shouldGitTag, latestBranch, tagName, 
 
     testing || await action();
     const attachments = [];
+    const finalPrefixGitTag = prefixGitTag || publishConfig['tag-version-prefix'] || '';
 
     const [text, success] = await gitTagMessage(
         onLatestBranch && shouldGitTag,
-        async() => testing || await git.tag(`${publishConfig['tag-version-prefix'] || ''}${version}`)
+        async() => testing || await git.tag(`${finalPrefixGitTag}${version}`)
     );
 
     text && attachments.push({ text, color: color(success) });

--- a/app/publish/index.js
+++ b/app/publish/index.js
@@ -91,11 +91,10 @@ module.exports = async function({ testing, shouldGitTag, prefixGitTag, latestBra
 
     testing || await action();
     const attachments = [];
-    const finalPrefixGitTag = prefixGitTag || publishConfig['tag-version-prefix'] || '';
 
     const [text, success] = await gitTagMessage(
         onLatestBranch && shouldGitTag,
-        async() => testing || await git.tag(`${finalPrefixGitTag}${version}`)
+        async() => testing || await git.tag(`${publishConfig['tag-version-prefix'] || prefixGitTag || ''}${version}`)
     );
 
     text && attachments.push({ text, color: color(success) });

--- a/app/spec.js
+++ b/app/spec.js
@@ -19,23 +19,25 @@ describe('index', async() => {
     afterEach(_afterEach);
     after(_after);
 
-    it('Should pass `testing` and `shouldGitTag` to "publish"', async() => {
+    it('Should pass `testing`, `shouldGitTag` and `prefixGitTag` to "publish"', async() => {
         let called = 0;
-        dummies.publish = ({ testing, shouldGitTag }) => {
+        dummies.publish = ({ testing, shouldGitTag, prefixGitTag }) => {
             called++;
             expect(testing).to.be.undefined;
             expect(shouldGitTag).to.be.undefined;
+            expect(prefixGitTag).to.be.undefined;
             return { message: 'dummy' };
         };
         await index();
 
-        dummies.publish = ({ testing, shouldGitTag }) => {
+        dummies.publish = ({ testing, shouldGitTag, prefixGitTag }) => {
             called++;
             expect(testing).to.be.true;
             expect(shouldGitTag).to.be.true;
+            expect(prefixGitTag).to.be('some-prefix');
             return { message: 'dummy' };
         };
-        await index({ testing: true, shouldGitTag: true });
+        await index({ testing: true, shouldGitTag: true, prefixGitTag: 'some-prefix' });
 
         expect(called).to.equal(2);
     });

--- a/bin/index.js
+++ b/bin/index.js
@@ -29,6 +29,7 @@ if (!slack.channel && process.env.SLACK_PUBLISHED_CHANNEL) {
         quiet: truthy(argv.quiet),
         testing: truthy(argv.testing) || _.includes('testing'),
         shouldGitTag: truthy(argv.gitTag),
+        prefixGitTag: argv.prefixGitTag,
         latestBranch: argv.latestBranch,
         tagName: argv.tagName,
         noSha: truthy(argv.noSha)

--- a/bin/spec.js
+++ b/bin/spec.js
@@ -54,6 +54,18 @@ describe('bin', () => {
         expect(called).to.be.true;
     });
 
+    it('Should be able to receive a prefix-git-tag argument', () => {
+        process.argv = 'node mocha --testing true --quiet true --git-tag true --prefix-git-tag some-prefix'.split(' ');
+        let called = false;
+        dummy.index = ({ shouldGitTag, prefixGitTag }) => {
+            called = true;
+            expect(shouldGitTag).to.be.true;
+            expect(prefixGitTag).to.be('some-prefix');
+        };
+        require('.');
+        expect(called).to.be.true;
+    });
+
     it('Should allow environment SLACK_WEBHOOK', () => {
         process.env.SLACK_WEBHOOK = 'https://www.webhook.net';
         let called = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "published",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "description": "📦 Opinionated NPM publish program",
   "keywords": [
     "npm",


### PR DESCRIPTION
Add support for: `npx published --git-tag --prefix-git-tag=some-prefix`.

### Why do we want this feature?
When a package is managed in a monorepo (in our case NX), in our case, we want the manager of the monorepo to own the publish flow and to own the git-tag.
We don't need the owner of the package itself to be aware about the value of the git-tag and we don't expect from him to add something in his `package.json`. 
Simply, when he works with our monorepo, he get by default a specific git tag when publishing the package.

> [!NOTE]
> Package owner still able to override the default prefix via `publishConfig.tag-version-prefix` from their `package.json`.